### PR TITLE
Fix partial-block OTA framing and document a verified V16 to V15 reflash

### DIFF
--- a/docs/io/11-ota-protocol.md
+++ b/docs/io/11-ota-protocol.md
@@ -7,6 +7,9 @@ reimplementation of the client framing and state machine. No physical UBOOT
 entry has been demonstrated; the observed update starts over USB-MIDI SysEx
 while the stock firmware is running.
 
+The [2026-09-04 V16 to stock V15 reflash](12-v15-reflash-proof.md) records a
+successful Windows MIDI run and corrects the partial-block framing below.
+
 ## Device identities
 
 | mode | observed VID:PID | enumerates as | MIDI |
@@ -47,23 +50,27 @@ The USB teardown records the template; host discovery uses the observed IDs.
 
 ## Read-request / data-response framing
 
-Device → host (request), host → device (response):
+Build the complete unpacked message, then encode it as one continuous
+LSB-first 8-to-7-bit stream between `F0` and `F7`:
 
 ```
-F0 00 32 41 41 [f1:4][addr:4][len:4] [pack7(data)…] F7
+00 59 30 | body_length:u24le | flash_type:u8 | address:u32le |
+requested_length:u24le | data (response only) | checksum:u8
 ```
 
-- `f1`, `addr`, `len` are three little-endian u32, each sent as 4×7-bit
-  groups (`b0|b1<<7|b2<<14|b3<<21`).
-- `len` field = `(length << 4) | flashtype`. Requests have `f1 = 0`;
-  responses have `f1 = length >> 4`.
-- `data` is an **8→7 LSB-first continuous bitstream** (7 wire bytes per 8
-  data bytes). The packed stream holds `length+1` unpacked bytes: the data
-  plus **one checksum byte** at the end:
-  `chk = ~(flashtype + sum(data) + sum(addr_LE_4) + sum(length_LE_3)) & 0xFF`
-  (length is plain little-endian u24, not the wire `(len<<4)` form; algorithm verified
-  48/48 against captured packets and against the firmware's verifier at
-  `update_cmd_dispatch 0x02026BC4`).
+- `body_length` is 8 for requests and `len(data) + 8` for responses.
+- `requested_length` is the exact requested payload size; ordinary responses
+  must contain that many bytes. The address retains all 32 bits, including
+  `0xE0000000` and `0xF0000000`.
+- `checksum = ~sum(bytes from flash_type through the end of data) & 0xFF`.
+- The device requires `body_length + 7 == decoded_packet_length` before
+  dispatching a command. A checksum-correct message can still fail this check.
+
+The former fixed `00 32 41 41` prefix only happened to encode the correct
+length for aligned blocks. A 481-byte response needs body length 489, whereas
+the old builder declared 488. The [vendor host builder](../../analysis/host-updater/ota_worker_decomp.c#L1455)
+writes the complete length before packing. See the
+[recorded failure, correction and reflash](12-v15-reflash-proof.md).
 
 ## The .fwsc logical image
 

--- a/docs/io/12-v15-reflash-proof.md
+++ b/docs/io/12-v15-reflash-proof.md
@@ -1,20 +1,18 @@
-# Verified V16 to stock V15 reflash - 2026-09-04
+# Verified rollback from a modified V15-derived build to stock V15 - 2026-09-04
 
-I got my FM-1 back from a modified V16 to stock V15 over USB. The application
-still answered MIDI commands, but its USB configuration descriptor was broken.
-An already-active Windows descriptor filter made the MIDI port available.
+I recovered my FM-1 from a locally modified firmware package back to stock V15 over USB. There is no official FM-1 V16 release involved here: the device reported version 16 only because my test package was derived from stock V15 and had its version identity intentionally bumped to 16 so the normal updater would accept the modified image.
 
-The failure was in the host response framing. The device's final 481-byte loader
-request got a reply declaring 488 body bytes while containing 489. The device
-checks that length before dispatching the response. Encoding the entire message
-fixed it. The same fix also matters for the 10-byte request near the end of the
-second stage.
+That distinction matters. This recovery demonstrates that the FM-1 can be moved backward from a higher reported version identity to an older stock package when the application is still running and the update transport remains reachable. In this case, the modified package had also broken the normal USB configuration descriptor, but an already-active Windows descriptor filter still exposed the MIDI port.
 
-The live run used a local Windows.Devices.Midi adapter. This PR brings the shared
-protocol corrections into the Linux client; it does not claim a hardware test of
-the ALSA transport. The adapter also needed to accept Windows' numbered port
-labels (`2 - USB-Midi`) and stock identity checksums. No Windows driver or
-replacement firmware is included here.
+The recovery failure turned out to be in the host response framing, not an anti-rollback fuse or permanent device-side downgrade block. The device's final 481-byte loader request got a reply declaring 488 body bytes while actually containing 489. The device checks that decoded length before dispatching the response, so it rejected the packet. Encoding the complete decoded message first and then packing it into MIDI-safe 7-bit bytes fixed the transfer. The same correction also applies to other partial-block requests.
+
+The live run used a local Windows.Devices.Midi adapter. This PR brings the shared protocol corrections into the Linux client; it does not claim a hardware test of the ALSA transport. The adapter also needed to accept Windows' numbered port labels (`2 - USB-Midi`) and stock identity checksums. No Windows driver or replacement firmware is included here.
+
+## What this proves
+
+The successful rollback is evidence that, for this tested path, the version restriction enforced by the normal updater is at least partly host-side policy rather than a one-way device fuse. The device was running a V15-derived test build that identified itself as version 16, and the corrected client successfully supplied the stock V15 package, completed the normal OTA write, rebooted, and returned as stock V15.
+
+This does not yet prove arbitrary rollback between every historical FM-1 release. Older packages may differ in metadata, loader behavior, or package layout and should still be checked before use. It also does not replace the lower-level JieLi USB_KEY/UBOOT recovery path for a hard brick where the application no longer runs or no usable update transport is reachable.
 
 ## Code path
 
@@ -36,13 +34,12 @@ in the [vendor disassembly](../../analysis/disassembly/app_pi32v2_objdump.txt#L5
 Stock V15 and its loader return a zero-padded plain identity, such as
 `ota-FM-1_015`. The client now reads that format while retaining the older
 encoded identity format. Stock replies use the one's-complement checksum.
-My modified V16 had kept V15's checksum after changing its version digit;
-the exception is limited to that exact captured V16 response.
+My modified V15-derived test build reported `FM-1_016` but retained V15's checksum after the version digit was changed; the exception is limited to that exact captured response.
 
 ## Instrumentation and observed result
 
 ```text
-read-only command: FM-1 V16 on 4C4A:C755
+read-only command: modified V15-derived test build reporting FM-1 V16 on 4C4A:C755
   -> hash-check the unchanged stock V15 package
   -> 48 staging data requests, then E0000000
   -> capture new USB identity 4D4A:4155
@@ -94,6 +91,8 @@ Expected first line:
 ```text
 Recorded capture chain verified: FM-1 V16 -> OTA V15 -> flash complete -> FM-1 V15.
 ```
+
+In that checker output, `FM-1 V16` is the captured identity of the locally modified V15-derived test package, not an official V16 firmware release.
 
 That command checks the supplied record's consistency. It does not independently
 authenticate a historical capture or perform another flash. The hardware result

--- a/docs/io/12-v15-reflash-proof.md
+++ b/docs/io/12-v15-reflash-proof.md
@@ -1,0 +1,108 @@
+# Verified V16 to stock V15 reflash - 2026-09-04
+
+I got my FM-1 back from a modified V16 to stock V15 over USB. The application
+still answered MIDI commands, but its USB configuration descriptor was broken.
+An already-active Windows descriptor filter made the MIDI port available.
+
+The failure was in the host response framing. The device's final 481-byte loader
+request got a reply declaring 488 body bytes while containing 489. The device
+checks that length before dispatching the response. Encoding the entire message
+fixed it. The same fix also matters for the 10-byte request near the end of the
+second stage.
+
+The live run used a local Windows.Devices.Midi adapter. This PR brings the shared
+protocol corrections into the Linux client; it does not claim a hardware test of
+the ALSA transport. The adapter also needed to accept Windows' numbered port
+labels (`2 - USB-Midi`) and stock identity checksums. No Windows driver or
+replacement firmware is included here.
+
+## Code path
+
+```text
+device requests logical offset + length
+  -> slice that exact number of bytes from the stock package
+  -> build [00 59 30][length+8][type][address][length][payload][checksum]
+  -> pack the complete message into 7-bit MIDI bytes
+  -> send the response
+  -> acknowledge E0000000 / F0000000 with success\0
+  -> verify the identity after the device returns
+```
+
+The complete header construction is visible in the existing
+[vendor packet builder](../../analysis/host-updater/ota_worker_decomp.c#L1455),
+`FUN_140017b20`. The device's length check is at V13 `0x02026BDA`/`0x02026BDC`
+in the [vendor disassembly](../../analysis/disassembly/app_pi32v2_objdump.txt#L56222).
+
+Stock V15 and its loader return a zero-padded plain identity, such as
+`ota-FM-1_015`. The client now reads that format while retaining the older
+encoded identity format. Stock replies use the one's-complement checksum.
+My modified V16 had kept V15's checksum after changing its version digit;
+the exception is limited to that exact captured V16 response.
+
+## Instrumentation and observed result
+
+```text
+read-only command: FM-1 V16 on 4C4A:C755
+  -> hash-check the unchanged stock V15 package
+  -> 48 staging data requests, then E0000000
+  -> capture new USB identity 4D4A:4155
+  -> command reply: ota-FM-1 V15
+  -> 1167 flash data requests, then F0000000
+  -> capture normal USB identity 4C4A:C755
+  -> separate read-only command: FM-1 V15
+  -> read raw USB descriptor: 293 bytes, valid walk
+  -> Windows enumeration: FM-1 Audio OK, FM-1 Midi OK
+```
+
+The image was `FM-1_015`, 699956 bytes (699936 after removing FWSC markers),
+SHA-256 `DB1642B2B6FA5C2CCCB11FFD13878068BB28601678D3644049F99DC40E7EDB8A`.
+The post-boot configuration descriptor SHA-256 was
+`8E5F630AEF8941ECDCC59628B616216D9C15AC25A1BB6A03A97C430A08614DBF`.
+
+The [redacted record](../../tools/tests/fixtures/fm1-v15-reflash-2026-09-04.json)
+preserves every requested address, length and flash type. Each run is
+`[first_address, length, flash_type, count, address_stride]`; expanding the runs
+reproduces all 49 first-stage and 1168 second-stage records, including their
+terminal requests. The data-request counts exclude those terminal records.
+It also contains the actual OTA identity reply and the separate post-boot
+observations. Original logs were retained locally and checked against their
+saved hash manifest before this allowlisted record was extracted. Host paths,
+device-instance IDs, serials and firmware payloads are excluded.
+
+## Check the evidence without touching hardware
+
+From the repository root:
+
+```sh
+python tools/verify_reflash_record.py
+python -m unittest discover -s tools/tests -v
+```
+
+The checker expands the captured requests, checks their bounds and counts,
+requires both terminal signals and the separate post-boot V15 observation,
+and decodes generated replies against the device's length/checksum contract.
+With no firmware supplied, it uses synthetic zero payloads for the wire checks.
+To replay the requested payload bytes from your own copy of the exact stock
+package, still without opening MIDI ports:
+
+```sh
+python tools/verify_reflash_record.py --firmware path/to/FM-1_V15.fwsc
+```
+
+Expected first line:
+
+```text
+Recorded capture chain verified: FM-1 V16 -> OTA V15 -> flash complete -> FM-1 V15.
+```
+
+That command checks the supplied record's consistency. It does not independently
+authenticate a historical capture or perform another flash. The hardware result
+comes from the recorded device observations. A terminal signal alone would not
+establish the installed version; changing the recorded post-boot version back to
+16 makes the check fail.
+
+This was the stock OTA erase/write process, without a separate whole-chip wipe,
+ROM recovery, flash readback or an audio playback test. The PC was not rebooted
+and no elevation prompt was needed during the reflash; the device reset itself
+through the normal update protocol. It is evidence for this unit and this path,
+not interrupted-update safety or recovery from an application that cannot run.

--- a/tools/README.md
+++ b/tools/README.md
@@ -19,6 +19,17 @@ for the observed terminal signals, and checks the post-reboot identity. Its
 packet codec and state machine have offline unit coverage, but current timing
 and recovery behavior have not been verified on available hardware.
 
+The [V16 to stock V15 record](../docs/io/12-v15-reflash-proof.md) documents a
+successful reflash through a local Windows MIDI adapter using the corrected
+framing. Check the redacted request sequence and generated packets offline:
+
+```sh
+python tools/verify_reflash_record.py
+```
+
+This checks saved evidence, not current hardware. The ALSA transport was not
+used in that live run. No firmware payload or Windows driver is included.
+
 ## UBOOT reference
 
 The pinned `3rd-party/jl-uboot-tool` submodule documents JieLi UBOOT discovery,

--- a/tools/fm1_ota.py
+++ b/tools/fm1_ota.py
@@ -18,13 +18,13 @@ Session flow:
      verifies the model/version again after reboot.
 
 Wire protocol (both directions):
-  F0 00 32 41 41 [f1:4][addr:4][len:4] [pack7(data)...] F7
-    f1/addr/len : three little-endian u32, each sent as 4 x 7-bit groups
-                  (b0|b1<<7|b2<<14|b3<<21). len field = (length<<4)|flashtype.
-    request     : device->host, f1=0
-    response    : host->device, f1 = length>>4
-    data        : 8->7 LSB-first bit-packed, plus one trailing checksum byte
-                  ~(flashtype+sum(data)+sum(addr_LE)+sum(len_LE3)) & 0xFF
+  F0 pack7(00 59 30 [body_len:u24le] [flashtype:u8] [addr:u32le]
+           [length:u24le] [data...] [checksum:u8]) F7
+    The complete message is one continuous 8->7 LSB-first bitstream.
+    request     : body_len=8, no data
+    response    : body_len=length+8, exactly length data bytes
+    checksum    : ~(flashtype+sum(addr_LE)+sum(length_LE3)+sum(data)) & 0xFF
+    A fixed packed prefix loses low body-length bits for partial blocks.
   Handshake:    F0 00 32 45 00 00 00 40 7F F7 -> ID block on 00 32 45 58
   Upgrade cmd:  F0 22 24 35 7F F7
   .fwsc image : the first 20*0x30 header bytes are interleaved as
@@ -82,17 +82,22 @@ def e7(v):
     return bytes([(v) & 0x7F, (v >> 7) & 0x7F, (v >> 14) & 0x7F, (v >> 21) & 0x7F])
 
 def build_response(addr, data, req_len=None, flashtype=0):
-    """Data response. req_len = requested length (echoed in the len field and
-    f1); the payload is the (full) data actually sent, followed by one
-    checksum byte: ~(flashtype+sum(data)+sum(addr_LE)+sum(len_LE3)) & 0xFF — algorithm
-    verified 48/48 against the firmware's verifier at update_cmd_dispatch
-    (0x02026BC4)."""
+    """Build the complete decoded response before packing, as M-UPGRADE does.
+
+    The body length is req_len + 8, including the flash type, address and
+    requested length. The checksum follows the body and covers all of it.
+    """
     if req_len is None:
         req_len = len(data)
-    chk = (~(flashtype + sum(data) + sum(addr.to_bytes(4, 'little'))
-             + sum(req_len.to_bytes(3, 'little')))) & 0xFF
-    return (b"\xF0" + HDR_DATA + e7(req_len >> 4) + e7(addr)
-            + e7((req_len << 4) | flashtype) + pack7(data + bytes([chk])) + b"\xF7")
+    if not 0 <= req_len <= MAXDATA or len(data) != req_len:
+        raise ValueError("response must contain the exact requested payload, at most 512 bytes")
+    if not 0 <= addr <= 0xFFFFFFFF or not 0 <= flashtype <= 0xFF:
+        raise ValueError("address or flash type is outside the wire field range")
+    body = (b"\x00\x59\x30" + (req_len + 8).to_bytes(3, "little")
+            + bytes([flashtype]) + addr.to_bytes(4, "little")
+            + req_len.to_bytes(3, "little") + data)
+    chk = (~sum(body[6:])) & 0xFF
+    return b"\xF0" + pack7(body + bytes([chk])) + b"\xF7"
 
 def parse_request(pkt):
     """Decode a device read-request frame -> (flashtype, addr, length) or None.
@@ -114,9 +119,10 @@ def parse_request(pkt):
 def parse_handshake_identity(pkt):
     """Decode the model and decimal version from a type-0x11 ID response.
 
-    This mirrors M-UPGRADE's parser at 0x140016e10. The 20-byte identity field
-    is stored relative to ASCII '0'; the parser adds '0' to each byte and uses
-    the underscore position from the plain identity field to find the version.
+    Stock V15 and its OTA loader return a plain, zero-padded identity. Also
+    retain the encoded-field format from M-UPGRADE's parser at 0x140016e10:
+    add ASCII '0' to the 20-byte field, then find the version using the plain
+    identity's underscore position.
     """
     if len(pkt) < 4 or pkt[0] != 0xF0 or pkt[-1] != 0xF7:
         return None
@@ -124,8 +130,21 @@ def parse_handshake_identity(pkt):
     if len(decoded) != 34 or decoded[:3] != b"\x00\x59\x11":
         return None
     body_len = int.from_bytes(decoded[3:6], "little")
-    if body_len != 27 or decoded[-1] != ((~sum(decoded[6:-1])) & 0xFF):
+    if body_len != 27:
         return None
+    # The observed custom V16 changed the version digit but retained V15's
+    # checksum. Permit only that exact legacy payload, not other bad checksums.
+    legacy_v16 = decoded[6:] == b"FM-1_016".ljust(27, b"\0") + b"\x19"
+    if decoded[-1] != ((~sum(decoded[6:-1])) & 0xFF) and not legacy_v16:
+        return None
+
+    plain_match = re.fullmatch(rb"([^_\x00]+)_([0-9]+)\x00*", decoded[6:-1])
+    if plain_match:
+        try:
+            model = plain_match.group(1).decode("ascii")
+        except UnicodeDecodeError:
+            return None
+        return {"model": model, "version": int(plain_match.group(2), 10)}
 
     plain = decoded[6:31]
     separator = plain.find(b"_")
@@ -145,10 +164,7 @@ def parse_handshake_identity(pkt):
 # "success" reply for the done-signals (verification/upgrade complete)
 def build_success(addr):
     payload = b"success\x00"
-    body = bytes([0x00, 0x59, 0x30]) + (len(payload) + 8).to_bytes(3, "little") \
-        + bytes([0]) + addr.to_bytes(4, "little") + len(payload).to_bytes(3, "little") + payload
-    chk = (~sum(body[6:])) & 0xFF
-    return b"\xF0" + pack7(body + bytes([chk])) + b"\xF7"
+    return build_response(addr, payload)
 
 # ------------------------------------------------------------- .fwsc image
 def fwsc_logical(path):
@@ -183,10 +199,11 @@ def fwsc_info(path):
     return {"chip": name, "product": product, "logical_size": len(lg)}
 
 # ------------------------------------------------------------------ rawmidi
-import alsalib, alsaseq
 
 def find_midi_port():
     """Locate the FM-1 kernel MIDI port (client, port), or None."""
+    import alsaseq
+
     c = alsaseq.SeqClient()
     try:
         for name in (b'USB Composite Device', b'FM-1', b'USB-Midi', b'Sinco-Midi'):
@@ -220,6 +237,8 @@ def find_rawmidi(prefer_ota=None):
 
 class MidiLink:
     def __init__(self, _path=None):
+        import alsalib
+
         self.link = alsalib.MidiLink()
         addr = find_midi_port()
         if not addr:

--- a/tools/tests/fixtures/fm1-v15-reflash-2026-09-04.json
+++ b/tools/tests/fixtures/fm1-v15-reflash-2026-09-04.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": 1,
+  "capture_date": "2026-09-04",
+  "firmware": {
+    "product": "FM-1_015",
+    "raw_size": 699956,
+    "logical_size": 699936,
+    "sha256": "DB1642B2B6FA5C2CCCB11FFD13878068BB28601678D3644049F99DC40E7EDB8A"
+  },
+  "transport": "Windows.Devices.Midi with an already-active descriptor filter",
+  "request_run_columns": [
+    "address_hex",
+    "length",
+    "flash_type",
+    "count",
+    "stride"
+  ],
+  "before": {
+    "model": "FM-1",
+    "version": 16,
+    "read_only": true,
+    "usb_id": "4C4A:C755"
+  },
+  "stage": {
+    "data_requests": 48,
+    "request_runs": [
+      ["0x00000000", 512, 0, 3, 512],
+      ["0x00000400", 512, 0, 2, 16384],
+      ["0x00000400", 32, 0, 1, 0],
+      ["0x00000400", 512, 0, 1, 0],
+      ["0x00004400", 32, 0, 1, 0],
+      ["0x000A5F00", 512, 0, 2, 32],
+      ["0x000A6120", 512, 0, 37, 512],
+      ["0x000AAB20", 481, 0, 1, 0],
+      ["0xE0000000", 8, 0, 1, 0]
+    ]
+  },
+  "ota": {
+    "usb_id": "4D4A:4155",
+    "model": "ota-FM-1",
+    "version": 15,
+    "identity_sysex_hex": "F0 00 32 45 58 01 00 40 37 74 42 35 31 54 29 4B 18 5F 60 44 29 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 2A F7"
+  },
+  "flash": {
+    "data_requests": 1167,
+    "request_runs": [
+      ["0x00000000", 512, 0, 3, 512],
+      ["0x00000400", 32, 0, 1, 0],
+      ["0x00000400", 512, 0, 2, 16384],
+      ["0x00004400", 32, 0, 7, 32],
+      ["0x00092640", 32, 0, 2, 32],
+      ["0x00000005", 16, 0, 4, 0],
+      ["0x00093200", 512, 0, 1144, -512],
+      ["0x00000100", 10, 0, 1, 0],
+      ["0x00000093", 16, 0, 3, 0],
+      ["0xF0000000", 8, 0, 1, 0]
+    ]
+  },
+  "after": {
+    "usb_id": "4C4A:C755",
+    "model": "FM-1",
+    "version": 15,
+    "read_only": true,
+    "descriptor": {
+      "length": 293,
+      "declared_length": 293,
+      "valid": true,
+      "sha256": "8E5F630AEF8941ECDCC59628B616216D9C15AC25A1BB6A03A97C430A08614DBF"
+    },
+    "interfaces": [
+      {
+        "name": "FM-1 Audio",
+        "status": "OK",
+        "problem": 0
+      },
+      {
+        "name": "FM-1 Midi",
+        "status": "OK",
+        "problem": 0
+      }
+    ]
+  },
+  "limitations": {
+    "raw_flash_readback": false,
+    "audio_io_tested": false,
+    "whole_chip_wipe": false
+  }
+}

--- a/tools/tests/test_fm1_ota.py
+++ b/tools/tests/test_fm1_ota.py
@@ -11,7 +11,6 @@ from unittest import mock
 TOOLS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, TOOLS)
 
-import alsalib
 import fm1_ota
 
 
@@ -31,6 +30,14 @@ def identity(name_version):
     payload = plain + encoded + bytes([0xD0]) * (19 - len(encoded))
     body = b"\x00\x59\x11" + len(payload).to_bytes(3, "little") + payload
     checksum = (~sum(payload)) & 0xFF
+    return b"\xF0" + fm1_ota.pack7(body + bytes([checksum])) + b"\xF7"
+
+
+def plain_identity(name_version, checksum=None):
+    payload = name_version.encode("ascii").ljust(27, b"\0")
+    body = b"\x00\x59\x11" + len(payload).to_bytes(3, "little") + payload
+    if checksum is None:
+        checksum = (~sum(payload)) & 0xFF
     return b"\xF0" + fm1_ota.pack7(body + bytes([checksum])) + b"\xF7"
 
 
@@ -64,16 +71,60 @@ class CodecTests(unittest.TestCase):
 
     def test_data_response_matches_known_packet(self):
         actual = fm1_ota.build_response(0x1234, b"\x00\x7f\x80\xff", 4)
-        expected = bytes.fromhex("f000324141000000003424000040000000007e017c7f16f7")
+        # The old 00 32 41 41 prefix declared 8 body bytes instead of 12.
+        expected = bytes.fromhex("f000324161000000003424000040000000007e017c7f16f7")
         self.assertEqual(actual, expected)
 
     def test_data_response_checksum_includes_flash_type(self):
         packet = fm1_ota.build_response(0x1234, b"\x00\x7f\x80\xff", 4, 3)
-        payload = fm1_ota.unpack7(packet[17:-1])
+        decoded = fm1_ota.unpack7(packet[1:-1])
         expected = (~(3 + sum(b"\x00\x7f\x80\xff")
                        + sum((0x1234).to_bytes(4, "little"))
                        + sum((4).to_bytes(3, "little")))) & 0xFF
-        self.assertEqual(payload[-1], expected)
+        self.assertEqual(decoded[-1], expected)
+
+    def test_response_contract_for_every_supported_length(self):
+        # The dispatcher requires body length + 7 == decoded packet length.
+        # Check this independently of the response builder, including every
+        # partial length and addresses that cannot fit in four 7-bit groups.
+        for length in range(513):
+            data = bytes((i * 37 + length) & 0xFF for i in range(length))
+            for addr, flash_type in ((0x000AAB20, 0), (0xFFFFFFFF, 0xFF)):
+                with self.subTest(length=length, addr=addr, flash_type=flash_type):
+                    packet = fm1_ota.build_response(addr, data, length, flash_type)
+                    self.assertEqual((packet[0], packet[-1]), (0xF0, 0xF7))
+                    self.assertTrue(all(byte < 0x80 for byte in packet[1:-1]))
+                    decoded = fm1_ota.unpack7(packet[1:-1])
+                    self.assertEqual(decoded[:3], b"\x00\x59\x30")
+                    self.assertEqual(int.from_bytes(decoded[3:6], "little"), length + 8)
+                    self.assertEqual(len(decoded), length + 15)
+                    self.assertEqual(decoded[6], flash_type)
+                    self.assertEqual(int.from_bytes(decoded[7:11], "little"), addr)
+                    self.assertEqual(int.from_bytes(decoded[11:14], "little"), length)
+                    self.assertEqual(decoded[14:-1], data)
+                    self.assertEqual(sum(decoded[6:]) & 0xFF, 0xFF)
+
+    def test_stock_v15_final_loader_block_declares_489_body_bytes(self):
+        # Observed final request: address 0xAAB20, length 481. Synthetic data
+        # reproduces the framing bug without redistributing vendor firmware.
+        packet = fm1_ota.build_response(0x000AAB20, bytes(481), 481)
+        decoded = fm1_ota.unpack7(packet[1:-1])
+        self.assertEqual(decoded[3:6], b"\xe9\x01\x00")
+        self.assertEqual(len(decoded), 496)
+
+    def test_response_rejects_wrong_payload_length(self):
+        for data, length in ((b"", -1), (b"short", 512), (b"long", 3), (bytes(513), 513)):
+            with self.subTest(length=length, actual_length=len(data)):
+                with self.assertRaisesRegex(ValueError, "exact requested payload"):
+                    fm1_ota.build_response(0, data, length)
+        with self.assertRaises(ValueError):
+            fm1_ota.build_response(0, bytes(513))
+
+    def test_response_rejects_out_of_range_wire_fields(self):
+        for addr, flash_type in ((-1, 0), (0x100000000, 0), (0, -1), (0, 256)):
+            with self.subTest(addr=addr, flash_type=flash_type):
+                with self.assertRaisesRegex(ValueError, "wire field range"):
+                    fm1_ota.build_response(addr, b"", flashtype=flash_type)
 
     def test_done_responses_match_updater(self):
         expected_verify = bytes.fromhex(
@@ -92,6 +143,62 @@ class CodecTests(unittest.TestCase):
         damaged = bytearray(packet)
         damaged[-2] ^= 1
         self.assertIsNone(fm1_ota.parse_handshake_identity(bytes(damaged)))
+
+    def test_handshake_accepts_stock_plain_identities(self):
+        for name, model in (("FM-1_015", "FM-1"), ("ota-FM-1_015", "ota-FM-1")):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    fm1_ota.parse_handshake_identity(plain_identity(name)),
+                    {"model": model, "version": 15},
+                )
+
+    def test_handshake_accepts_observed_41_byte_stock_ota_frame(self):
+        # Read-only identity query captured on 2026-09-04; only public model,
+        # version, padding and checksum are present (no serial or device ID).
+        packet = bytes.fromhex(
+            "f0 00 32 45 58 01 00 40 37 74 42 35 31 54 29 4b 18 5f 60 44 29 03 "
+            "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 2a f7")
+        self.assertEqual(len(packet), 41)
+        self.assertEqual(
+            fm1_ota.parse_handshake_identity(packet),
+            {"model": "ota-FM-1", "version": 15},
+        )
+        decoded = fm1_ota.unpack7(packet[1:-1])
+        self.assertEqual(decoded[-1], 0xA8)
+        self.assertEqual(sum(decoded[6:]) & 0xFF, 0xFF)
+        # Corrupt one payload byte or the checksum without repairing the sum.
+        for offset in (8, 20, -2):
+            damaged = bytearray(packet)
+            damaged[offset] ^= 1
+            with self.subTest(offset=offset):
+                self.assertIsNone(fm1_ota.parse_handshake_identity(bytes(damaged)))
+
+    def test_handshake_legacy_checksum_exception_is_exact(self):
+        self.assertEqual(
+            fm1_ota.parse_handshake_identity(plain_identity("FM-1_016", checksum=0x19)),
+            {"model": "FM-1", "version": 16},
+        )
+        for name, checksum in (("FM-1_017", 0x19), ("ota-FM-1_016", 0x19),
+                               ("FM-1_016", 0x1A), ("FM-1_015", 0)):
+            with self.subTest(name=name, checksum=checksum):
+                self.assertIsNone(
+                    fm1_ota.parse_handshake_identity(plain_identity(name, checksum)))
+        decoded = bytearray(fm1_ota.unpack7(plain_identity("FM-1_016", 0x19)[1:-1]))
+        decoded[-2] = 1  # Same visible name, but no longer the exact legacy payload.
+        self.assertIsNone(fm1_ota.parse_handshake_identity(
+            b"\xF0" + fm1_ota.pack7(decoded) + b"\xF7"))
+
+    def test_handshake_rejects_invalid_header_length_and_framing(self):
+        packet = plain_identity("FM-1_015")
+        for invalid in (b"", packet[1:], packet[:-1], packet + b"\x00"):
+            with self.subTest(packet=invalid):
+                self.assertIsNone(fm1_ota.parse_handshake_identity(invalid))
+        for offset, value in ((0, 1), (2, 0x12), (3, 26)):
+            decoded = bytearray(fm1_ota.unpack7(packet[1:-1]))
+            decoded[offset] = value
+            with self.subTest(offset=offset):
+                self.assertIsNone(fm1_ota.parse_handshake_identity(
+                    b"\xF0" + fm1_ota.pack7(decoded) + b"\xF7"))
 
 
 class TransferTests(unittest.TestCase):
@@ -126,14 +233,18 @@ class ImageTests(unittest.TestCase):
     def test_logical_image_strips_twenty_marker_bytes(self):
         header = b"".join(bytes([i]) * 47 + bytes([0xA0 + i]) for i in range(20))
         tail = b"payload"
-        with tempfile.NamedTemporaryFile() as image:
-            image.write(header + tail)
-            image.flush()
-            logical = fm1_ota.fwsc_logical(image.name)
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "test.fwsc")
+            with open(path, "wb") as image:
+                image.write(header + tail)
+            logical = fm1_ota.fwsc_logical(path)
         expected = b"".join(bytes([i]) * 47 for i in range(20)) + tail
         self.assertEqual(logical, expected)
 
+    @unittest.skipUnless(sys.platform.startswith("linux"), "ALSA layout requires Linux/libasound")
     def test_alsa_pollfd_layout(self):
+        import alsalib
+
         self.assertEqual(ctypes.sizeof(alsalib.PollFD), 8)
         self.assertEqual(alsalib.PollFD.events.offset, 4)
         self.assertEqual(alsalib.PollFD.revents.offset, 6)

--- a/tools/tests/test_reflash_record.py
+++ b/tools/tests/test_reflash_record.py
@@ -1,0 +1,45 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from verify_reflash_record import DEFAULT_RECORD, verify
+
+
+class ReflashRecordTests(unittest.TestCase):
+    def setUp(self):
+        self.record = json.loads(DEFAULT_RECORD.read_text(encoding="utf-8"))
+
+    def test_recorded_chain_and_response_framing(self):
+        self.assertIn("Recorded capture chain verified", verify(self.record))
+
+    def test_terminal_alone_does_not_prove_installed_version(self):
+        self.record["after"]["version"] = 16
+        with self.assertRaisesRegex(ValueError, "post-boot V15"):
+            verify(self.record)
+
+    def test_rejects_verification_signal_as_flash_completion(self):
+        self.record["flash"]["request_runs"][-1][0] = "0xE0000000"
+        with self.assertRaisesRegex(ValueError, "missing completion"):
+            verify(self.record)
+
+    def test_rejects_incomplete_request_stream(self):
+        self.record["flash"]["request_runs"].pop(0)
+        with self.assertRaisesRegex(ValueError, "request count"):
+            verify(self.record)
+
+    def test_rejects_wrong_package_and_invalid_descriptor(self):
+        for field in ("package", "descriptor"):
+            record = copy.deepcopy(self.record)
+            if field == "package":
+                record["firmware"]["sha256"] = "0" * 64
+            else:
+                record["after"]["descriptor"]["valid"] = False
+            with self.subTest(field=field), self.assertRaises(ValueError):
+                verify(record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify_reflash_record.py
+++ b/tools/verify_reflash_record.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Check the redacted V16 -> stock V15 capture record offline; no device I/O."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from fm1_ota import build_response, build_success, fwsc_logical, parse_handshake_identity, unpack7
+
+STOCK_V15_SHA256 = "DB1642B2B6FA5C2CCCB11FFD13878068BB28601678D3644049F99DC40E7EDB8A"
+DEFAULT_RECORD = Path(__file__).parent / "tests/fixtures/fm1-v15-reflash-2026-09-04.json"
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def expand_requests(runs):
+    for address, length, flash_type, count, stride in runs:
+        require(all(type(value) is int for value in (length, flash_type, count, stride)),
+                "request run fields must be integers")
+        require(0 < count <= 4096, "invalid request run count")
+        for index in range(count):
+            yield int(address, 16) + index * stride, length, flash_type
+
+
+def check_frame(frame, address, data, flash_type):
+    require(frame[0] == 0xF0 and frame[-1] == 0xF7, "missing SysEx delimiters")
+    require(all(byte < 128 for byte in frame[1:-1]), "non-MIDI byte in SysEx")
+    decoded = unpack7(frame[1:-1])
+    require(decoded[:3] == b"\x00\x59\x30", "wrong response command")
+    require(int.from_bytes(decoded[3:6], "little") == len(decoded) - 7 == len(data) + 8,
+            "response body length mismatch")
+    require(decoded[6] == flash_type and int.from_bytes(decoded[7:11], "little") == address,
+            "response target fields mismatch")
+    require(int.from_bytes(decoded[11:14], "little") == len(data) and decoded[14:-1] == data,
+            "response payload mismatch")
+    require(sum(decoded[6:]) & 255 == 255, "response checksum mismatch")
+
+
+def verify(record, firmware=None):
+    require(record["schema_version"] == 1, "unknown record schema")
+    require(record["request_run_columns"] == ["address_hex", "length", "flash_type", "count", "stride"],
+            "unknown request encoding")
+    image = record["firmware"]
+    require(image["product"] == "FM-1_015" and image["sha256"] == STOCK_V15_SHA256,
+            "record is not the stock V15 package")
+    require((image["raw_size"], image["logical_size"]) == (699956, 699936), "package size mismatch")
+    logical = None
+    if firmware is not None:
+        raw = Path(firmware).read_bytes()
+        require(hashlib.sha256(raw).hexdigest().upper() == image["sha256"], "firmware SHA-256 mismatch")
+        logical = fwsc_logical(firmware)
+        require(len(logical) == image["logical_size"], "logical image size mismatch")
+
+    before, ota, after = record["before"], record["ota"], record["after"]
+    require((before["model"], before["version"], before["usb_id"], before["read_only"])
+            == ("FM-1", 16, "4C4A:C755", True), "missing initial read-only V16 observation")
+    require(ota["usb_id"] == "4D4A:4155", "missing OTA enumeration")
+    identity = parse_handshake_identity(bytes.fromhex(ota["identity_sysex_hex"]))
+    require(identity == {"model": "ota-FM-1", "version": 15}
+            and (ota["model"], ota["version"]) == ("ota-FM-1", 15), "OTA identity mismatch")
+
+    for name, finish, expected_count in (("stage", 0xE0000000, 48), ("flash", 0xF0000000, 1167)):
+        requests = list(expand_requests(record[name]["request_runs"]))
+        require(len(requests) - 1 == record[name]["data_requests"] == expected_count,
+                f"{name}: recorded request count mismatch")
+        require(requests[-1] == (finish, 8, 0), f"{name}: missing completion request")
+        for address, length, flash_type in requests[:-1]:
+            require(0 <= address and 0 < length <= 512 and address + length <= image["logical_size"],
+                    f"{name}: request outside logical image")
+            data = logical[address:address + length] if logical is not None else bytes(length)
+            check_frame(build_response(address, data, length, flash_type), address, data, flash_type)
+        check_frame(build_success(finish), finish, b"success\0", 0)
+    require((0xAAB20, 481, 0) in list(expand_requests(record["stage"]["request_runs"])),
+            "missing the observed partial loader block")
+
+    require((after["model"], after["version"], after["usb_id"], after["read_only"])
+            == ("FM-1", 15, "4C4A:C755", True), "missing separate post-boot V15 observation")
+    descriptor = after["descriptor"]
+    require(descriptor["length"] == descriptor["declared_length"] == 293 and descriptor["valid"] is True,
+            "invalid post-boot USB descriptor")
+    interfaces = {item["name"]: (item["status"], item["problem"]) for item in after["interfaces"]}
+    require(all(interfaces.get(name) == ("OK", 0) for name in ("FM-1 Audio", "FM-1 Midi")),
+            "missing healthy audio/MIDI enumeration")
+    return "Recorded capture chain verified: FM-1 V16 -> OTA V15 -> flash complete -> FM-1 V15."
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("record", nargs="?", type=Path, default=DEFAULT_RECORD)
+    parser.add_argument("--firmware", type=Path, help="optional local stock V15 package for payload replay")
+    args = parser.parse_args()
+    try:
+        print(verify(json.loads(args.record.read_text(encoding="utf-8")), args.firmware))
+        print("Offline only: checks the supplied record and framing; does not authenticate a past flash or contact hardware.")
+        print("Payload replay:", "verified local stock package" if args.firmware else "synthetic zero payloads; firmware not supplied")
+        return 0
+    except (ValueError, KeyError, TypeError, OSError) as error:
+        print(f"Record check failed: {error}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
I got my FM-1 back from a modified V16 to stock V15 over USB. Your reverse-engineering work made it possible to find the problem.

The last loader block was 481 bytes. The reply declared a 488-byte body but contained 489, so the device dropped it. This packs the complete reply before MIDI encoding, as the vendor updater does. It also handles the plain V15/OTA identity replies while keeping the older encoded format and the exact observed V16 checksum exception.

I've included a small code fix, regression tests, and the instrumentation flow from the actual reflash:

```text
FM-1 V16
  -> 48 staging requests + E0000000
  -> OTA USB identity + ota-FM-1 V15
  -> 1167 flash requests + F0000000
  -> separate post-boot command: FM-1 V15
  -> valid 293-byte USB descriptor; Audio and MIDI enumerate OK
```

The redacted record retains the full request sequence in 19 short runs. Reviewers can check it without touching hardware:

```sh
python tools/verify_reflash_record.py
python -m unittest discover -s tools/tests -v
```

Validation: 26 tests passed on Windows; one Linux/ALSA layout test was explicitly skipped. The record checker also passed with the actual SHA-256-locked V15 package supplied locally.

The live run used a local Windows MIDI adapter with a descriptor filter already active. This PR ports the protocol fixes into the Linux client; I haven't hardware-tested the ALSA transport. It was the stock OTA erase/write process, with no separate whole-chip wipe or flash readback. The record contains no firmware payloads, serials, device-instance IDs or host paths.
